### PR TITLE
Fix: Hide Generatepress upsell link when displaying the search results

### DIFF
--- a/assets/js/customizer-search-admin.js
+++ b/assets/js/customizer-search-admin.js
@@ -132,6 +132,10 @@
 				$foundPanel.addClass('search-found');
 				$found.siblings('.control-section').removeClass('search-found').addClass('search-not-found');
 				$foundPanel.siblings('.control-section').removeClass('search-found').addClass('search-not-found');
+
+				if ( $( '.generate-upsell-accordion-section' ).length > 0 ) {
+					$( '.generate-upsell-accordion-section' ).removeClass('search-found').addClass('search-not-found');
+				}
 			});
 		},
 


### PR DESCRIPTION
Fixes #4 